### PR TITLE
Messages can be empty causing uncaught exceptions

### DIFF
--- a/src/main/java/com/ihtasham/Listeners/MessageListener.java
+++ b/src/main/java/com/ihtasham/Listeners/MessageListener.java
@@ -29,7 +29,17 @@ public class MessageListener extends ListenerAdapter {
     final String guildId = event.getGuild().getId();
     final String message = event.getMessage().getContentRaw();
 
-    if (!message.isEmpty() && message.charAt(0) != Constants.COMMAND_PREFIX) {
+    if (message.isEmpty() || message.isBlank()) {
+      log.warn("The message was empty or blank, ignoring event");
+      return;
+    }
+
+    if (guildId.isEmpty() || guildId.isBlank()) {
+      log.warn("The guildId was empty or blank, ignoring event");
+      return;
+    }
+
+    if (message.charAt(0) != Constants.COMMAND_PREFIX) {
       log.debug("Message received was not a command, ignoring event");
       return;
     }

--- a/src/main/java/com/ihtasham/Listeners/MessageListener.java
+++ b/src/main/java/com/ihtasham/Listeners/MessageListener.java
@@ -29,7 +29,7 @@ public class MessageListener extends ListenerAdapter {
     final String guildId = event.getGuild().getId();
     final String message = event.getMessage().getContentRaw();
 
-    if (message.charAt(0) != Constants.COMMAND_PREFIX) {
+    if (!message.isEmpty() && message.charAt(0) != Constants.COMMAND_PREFIX) {
       log.debug("Message received was not a command, ignoring event");
       return;
     }


### PR DESCRIPTION
The following exception has been seem quite a few times:

```
2022-04-16T01:12:48.081277+00:00 app[worker.1]: 01:12:48.080 [JDA MainWS-ReadThread] ERROR net.dv8tion.jda.api.JDA - One of the EventListeners had an uncaught exception
2022-04-16T01:12:48.081287+00:00 app[worker.1]: java.lang.StringIndexOutOfBoundsException: String index out of range: 0
2022-04-16T01:12:48.081288+00:00 app[worker.1]: at java.lang.StringLatin1.charAt(StringLatin1.java:47) ~[?:?]
2022-04-16T01:12:48.081288+00:00 app[worker.1]: at java.lang.String.charAt(String.java:693) ~[?:?]
2022-04-16T01:12:48.081289+00:00 app[worker.1]: at com.ihtasham.Listeners.MessageListener.onMessageReceived(MessageListener.java:32) ~[discord-roll-bot.jar:?]
```

This suggests that the `event.getMessage().getContentRaw()` method must be returning an empty message at some point.

This PR will attempt to be more careful in handling messages and as a bonus also the `GuildId` as that could potentially also be empty. 